### PR TITLE
修复一处错误 basic/advanced_type/array.md

### DIFF
--- a/course/basic/advanced_type/array.md
+++ b/course/basic/advanced_type/array.md
@@ -23,7 +23,7 @@ pub fn main() !void {
     const message = [5]u8{ 'h', 'e', 'l', 'l', 'o' };
     // const message = [_]u8{ 'h', 'e', 'l', 'l', 'o' };
     print("{s}\n", .{message}); // hello
-    print("{s}\n", .{message[0]}); // h
+    print("{h}\n", .{message[0]}); // h
 }
 ```
 

--- a/course/basic/advanced_type/array.md
+++ b/course/basic/advanced_type/array.md
@@ -23,7 +23,7 @@ pub fn main() !void {
     const message = [5]u8{ 'h', 'e', 'l', 'l', 'o' };
     // const message = [_]u8{ 'h', 'e', 'l', 'l', 'o' };
     print("{s}\n", .{message}); // hello
-    print("{h}\n", .{message[0]}); // h
+    print("{c}\n", .{message[0]}); // h
 }
 ```
 


### PR DESCRIPTION
修复一处错误 basic/advanced_type/array.md

原代码无法通过编译，且存在使用"{s}“参数输出字符的问题

```bash
/usr/lib/zig/std/fmt.zig:459:5: error: invalid format string 's' for type 'u8'
    @compileError("invalid format string '" ++ fmt ++ "' for type '" ++ @typeName(@TypeOf(value)) ++ "'");
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```