### PR TITLE
更新std.Thread.Mutex文档链接

### DIFF
--- a/course/hello-world.md
+++ b/course/hello-world.md
@@ -73,7 +73,7 @@ zig 会自动为我们根据后面的参量表推导出对应的类型，当 zig
 
 上面我们已经完成了带有缓冲区的“打印”，这很棒！
 
-但是，它还没有多线程支持，所以我们可能需要添加一个**锁**来保证打印函数的先后执行顺序，你可以使用 `std.Thread.Mutex`，它的文档在[_这里_](https://ziglang.org/documentation/master/std/#A;std:Thread.Mutex)，但我更推荐你结合标准库的源码来了解它。
+但是，它还没有多线程支持，所以我们可能需要添加一个**锁**来保证打印函数的先后执行顺序，你可以使用 `std.Thread.Mutex`，它的文档在[_这里_](https://ziglang.org/documentation/master/std/#std.Thread.Mutex)，但我更推荐你结合标准库的源码来了解它。
 
 ## 了解更多？
 


### PR DESCRIPTION
原std.Thread.Mutex文档链接https://ziglang.org/documentation/master/std/#A;std:Thread.Mutex 失效，
更新为https://ziglang.org/documentation/master/std/#std.Thread.Mutex