### PR TITLE
改进非详尽枚举与 `@enumFromInt` 的说明

### DIFF
--- a/course/basic/advanced_type/enum.md
+++ b/course/basic/advanced_type/enum.md
@@ -4,7 +4,7 @@ outline: deep
 
 # 枚举
 
-> 举常常用来列出一个有限集合的任何成员，或者对某一种特定对象的计数。
+> 枚举常常用来列出一个有限集合的任何成员，或者对某一种特定对象的计数。
 
 枚举是一种相对简单，但用处颇多的类型。
 
@@ -50,15 +50,19 @@ outline: deep
 
 ## 非详尽枚举
 
-zig 允许我们不列出所有的枚举值，未列出枚举值可以使用 `_` 代替。
+zig 允许我们不列出所有的枚举值，未列出枚举值可以使用 `_` 代替。由于未列出枚举值的存在，枚举的大小无法自动推断，必须显式指定。
+
+<<<@/code/release/enum.zig#non_exhaustive_enum
 
 :::info 🅿️ 提示
 
-`@enumFromInt` 允许我们通过一个整数来反推一个枚举，但需要注意，尝试转换一个在所选枚举类型中没有表示值的整数会导致[未定义行为（Undefined Behavior）](https://ziglang.org/documentation/master/#Undefined-Behavior)
+`@enumFromInt` 能够将整数转换为枚举值。但需要注意，如果所选枚举类型中没有表示该整数的值，就会导致[未定义行为](../../more/undefined_behavior#无效枚举转换)。
+
+如果目标枚举类型是非详尽枚举，那么除了涉及 `@intCast` 相关的安全检查之外，`@enumFromInt` 始终能够得到有效的枚举值。
 
 :::
 
-<<<@/code/release/enum.zig#non_exhaustive_enum
+<<<@/code/release/enum.zig#enum_from_int
 
 ## `EnumLiteral`
 

--- a/course/code/12/enum.zig
+++ b/course/code/12/enum.zig
@@ -1,6 +1,7 @@
 pub fn main() !void {
     try EnumSize.main();
     try EnumReference.main();
+    try Non_exhaustiveEnum.main();
 }
 
 // #region basic_enum
@@ -114,6 +115,33 @@ const Non_exhaustiveEnum = struct {
     };
     // is_one 也是true
     // #endregion non_exhaustive_enum
+
+    const std = @import("std");
+    const expect = std.testing.expect;
+
+    pub fn main() !void {
+        // #region enum_from_int
+        const Color = enum(u4) {
+            red,
+            green,
+            blue,
+            _,
+        };
+
+        // 明确列出的枚举值
+        const blue: Color = @enumFromInt(2);
+        try expect(blue == .blue);
+
+        // 未列出的枚举值：8 在 u4 的范围内（0~15）
+        const yellow: Color = @enumFromInt(8);
+        try expect(@TypeOf(yellow) == Color);
+        try expect(@intFromEnum(yellow) == 8);
+
+        // 42 超出了 u4 的范围，会触发未定义行为
+        // const ub: Color = @enumFromInt(42);
+
+        // #endregion enum_from_int
+    }
 };
 
 const EnumLiteral_ = struct {

--- a/course/code/14/enum.zig
+++ b/course/code/14/enum.zig
@@ -114,6 +114,33 @@ const Non_exhaustiveEnum = struct {
     };
     // is_one 也是true
     // #endregion non_exhaustive_enum
+
+    const std = @import("std");
+    const expect = std.testing.expect;
+
+    pub fn main() !void {
+        // #region enum_from_int
+        const Color = enum(u4) {
+            red,
+            green,
+            blue,
+            _,
+        };
+
+        // 明确列出的枚举值
+        const blue: Color = @enumFromInt(2);
+        try expect(blue == .blue);
+
+        // 未列出的枚举值：8 在 u4 的范围内（0~15）
+        const yellow: Color = @enumFromInt(8);
+        try expect(@TypeOf(yellow) == Color);
+        try expect(@intFromEnum(yellow) == 8);
+
+        // 42 超出了 u4 的范围，会触发未定义行为
+        // const ub: Color = @enumFromInt(42);
+
+        // #endregion enum_from_int
+    }
 };
 
 const EnumLiteral_ = struct {


### PR DESCRIPTION
原有描述可能存在歧义：读者可能觉得之所以要把这个提示放在「非详尽枚举」这里，就是要强调使用未列出的值调用 `@enumFromInt` 是未定义行为。

所以我把 `@enumFromInt` 对非详尽枚举的行为单独写出来了，以示区别。

p.s. 顺便修复了这一章开头的一个笔误。