### PR TITLE
修复标准库链接

### DIFF
--- a/course/advanced/memory_manage.md
+++ b/course/advanced/memory_manage.md
@@ -51,7 +51,7 @@ outline: deep
 
 ## `FixedBufferAllocator`
 
-这个分配器是固定大小的内存缓冲区，无法扩容，常常在你需要缓冲某些东西时使用，注意默认情况下它不是线程安全的，但是存在着变体 [`ThreadSafeAllocator`](https://ziglang.org/documentation/master/std/#A;std:heap.ThreadSafeAllocator)，使用 `ThreadSafeAllocator` 包裹一下它即可。
+这个分配器是固定大小的内存缓冲区，无法扩容，常常在你需要缓冲某些东西时使用，注意默认情况下它不是线程安全的，但是存在着变体 [`ThreadSafeAllocator`](https://ziglang.org/documentation/master/std/#std.heap.ThreadSafeAllocator)，使用 `ThreadSafeAllocator` 包裹一下它即可。
 
 ::: code-group
 

--- a/course/basic/advanced_type/enum.md
+++ b/course/basic/advanced_type/enum.md
@@ -72,9 +72,9 @@ zig 允许我们不列出所有的枚举值，未列出枚举值可以使用 `_`
 
 :::
 
-zig 还包含另外一个特殊的类型 `EnumLiteral`，它是 [`std.builtin.Type`](https://ziglang.org/documentation/master/std/#A;std:builtin.Type) 的一部分。
+zig 还包含另外一个特殊的类型 `EnumLiteral`，它是 [`std.builtin.Type`](https://ziglang.org/documentation/master/std/#std.builtin.Type) 的一部分。
 
-可以将它称之为“枚举字面量”，它是一个与 `enum` 完全不同的类型，可以查看 zig 类型系统对 `enum` 的 [定义](https://ziglang.org/documentation/master/std/#A;std:builtin.Type.Enum)，并不包含 `EnumLiteral`！
+可以将它称之为“枚举字面量”，它是一个与 `enum` 完全不同的类型，可以查看 zig 类型系统对 `enum` 的 [定义](https://ziglang.org/documentation/master/std/#std.builtin.Type.Enum)，并不包含 `EnumLiteral`！
 
 它的具体使用如下：
 

--- a/course/basic/basic_type/function.md
+++ b/course/basic/basic_type/function.md
@@ -126,4 +126,4 @@ extern 关键字后面带引号的标识符指定具有该函数的库，例如 
 
 <<<@/code/release/function.zig#shiftLeftOne
 
-关于可以使用的调用约定格式，可以参考这里[`std.builtin.CallingConvention`](https://ziglang.org/documentation/master/std/#A;std:builtin.CallingConvention)。
+关于可以使用的调用约定格式，可以参考这里[`std.builtin.CallingConvention`](https://ziglang.org/documentation/master/std/#std.builtin.CallingConvention)。


### PR DESCRIPTION
部分链接使用的仍然是 0.12.0 之前的旧格式，已失效，打开后只会显示

> Declaration not found.