### PR TITLE
docs: 数组章节使用 comptime 标签块初始化 fancy_array

### DIFF
--- a/course/basic/advanced_type/array.md
+++ b/course/basic/advanced_type/array.md
@@ -94,4 +94,4 @@ outline: deep
 
 <<<@/code/release/array.zig#comptime_init_array
 
-在这个示例中，我们利用编译期执行的特性来初始化数组，并结合了 `blocks` 和 `break` 的用法。关于这些，我们将在[循环](/basic/process_control/loop)章节中详细讲解。
+在这个示例中，我们利用编译期执行的特性来初始化数组，并结合了 `blocks` 和 `break` 的用法。关于这些，我们将在[循环](/basic/process_control/loop)章节中详细讲解。你也可以通过 [Compiler Explorer](https://godbolt.org/z/oWdjqajPa) 在线运行该示例查看结果。

--- a/course/code/11/array.zig
+++ b/course/code/11/array.zig
@@ -145,7 +145,7 @@ const ComptimeInitArray = struct {
     const print = @import("std").debug.print;
 
     pub fn main() void {
-        const fancy_array = init: {
+        const fancy_array = comptime init: {
             var initial_value: [10]usize = undefined;
             for (&initial_value, 0..) |*pt, i| {
                 pt.* = i;

--- a/course/code/11/array.zig
+++ b/course/code/11/array.zig
@@ -143,6 +143,7 @@ const FuncInitArray = struct {
 const ComptimeInitArray = struct {
     // #region comptime_init_array
     const print = @import("std").debug.print;
+    const assert = @import("std").debug.assert;
 
     pub fn main() void {
         const fancy_array = comptime init: {
@@ -152,6 +153,7 @@ const ComptimeInitArray = struct {
             }
             break :init initial_value;
         };
+        comptime assert(fancy_array[9] == 9);
         print("{any}\n", .{fancy_array});
     }
     // #endregion comptime_init_array

--- a/course/code/12/array.zig
+++ b/course/code/12/array.zig
@@ -99,6 +99,7 @@ const FuncInitArray = struct {
 const ComptimeInitArray = struct {
     // #region comptime_init_array
     const print = @import("std").debug.print;
+    const assert = @import("std").debug.assert;
 
     pub fn main() void {
         const fancy_array = comptime init: {
@@ -108,6 +109,7 @@ const ComptimeInitArray = struct {
             }
             break :init initial_value;
         };
+        comptime assert(fancy_array[9] == 9);
         print("{any}\n", .{fancy_array});
     }
     // #endregion comptime_init_array

--- a/course/code/12/array.zig
+++ b/course/code/12/array.zig
@@ -101,7 +101,7 @@ const ComptimeInitArray = struct {
     const print = @import("std").debug.print;
 
     pub fn main() void {
-        const fancy_array = init: {
+        const fancy_array = comptime init: {
             var initial_value: [10]usize = undefined;
             for (&initial_value, 0..) |*pt, i| {
                 pt.* = i;

--- a/course/code/14/array.zig
+++ b/course/code/14/array.zig
@@ -121,6 +121,7 @@ const FuncInitArray = struct {
 const ComptimeInitArray = struct {
     // #region comptime_init_array
     const print = @import("std").debug.print;
+    const assert = @import("std").debug.assert;
 
     pub fn main() void {
         const fancy_array = comptime init: {
@@ -130,6 +131,7 @@ const ComptimeInitArray = struct {
             }
             break :init initial_value;
         };
+        comptime assert(fancy_array[9] == 9);
         print("{any}\n", .{fancy_array});
     }
     // #endregion comptime_init_array

--- a/course/code/14/array.zig
+++ b/course/code/14/array.zig
@@ -123,7 +123,7 @@ const ComptimeInitArray = struct {
     const print = @import("std").debug.print;
 
     pub fn main() void {
-        const fancy_array = init: {
+        const fancy_array = comptime init: {
             var initial_value: [10]usize = undefined;
             for (&initial_value, 0..) |*pt, i| {
                 pt.* = i;

--- a/course/code/15/array.zig
+++ b/course/code/15/array.zig
@@ -121,6 +121,7 @@ const FuncInitArray = struct {
 const ComptimeInitArray = struct {
     // #region comptime_init_array
     const print = @import("std").debug.print;
+    const assert = @import("std").debug.assert;
 
     pub fn main() void {
         const fancy_array = comptime init: {
@@ -130,6 +131,7 @@ const ComptimeInitArray = struct {
             }
             break :init initial_value;
         };
+        comptime assert(fancy_array[9] == 9);
         print("{any}\n", .{fancy_array});
     }
     // #endregion comptime_init_array

--- a/course/code/15/array.zig
+++ b/course/code/15/array.zig
@@ -123,7 +123,7 @@ const ComptimeInitArray = struct {
     const print = @import("std").debug.print;
 
     pub fn main() void {
-        const fancy_array = init: {
+        const fancy_array = comptime init: {
             var initial_value: [10]usize = undefined;
             for (&initial_value, 0..) |*pt, i| {
                 pt.* = i;

--- a/course/code/16/array.zig
+++ b/course/code/16/array.zig
@@ -121,6 +121,7 @@ const FuncInitArray = struct {
 const ComptimeInitArray = struct {
     // #region comptime_init_array
     const print = @import("std").debug.print;
+    const assert = @import("std").debug.assert;
 
     pub fn main() void {
         const fancy_array = comptime init: {
@@ -130,6 +131,7 @@ const ComptimeInitArray = struct {
             }
             break :init initial_value;
         };
+        comptime assert(fancy_array[9] == 9);
         print("{any}\n", .{fancy_array});
     }
     // #endregion comptime_init_array

--- a/course/code/16/array.zig
+++ b/course/code/16/array.zig
@@ -123,7 +123,7 @@ const ComptimeInitArray = struct {
     const print = @import("std").debug.print;
 
     pub fn main() void {
-        const fancy_array = init: {
+        const fancy_array = comptime init: {
             var initial_value: [10]usize = undefined;
             for (&initial_value, 0..) |*pt, i| {
                 pt.* = i;

--- a/course/code/release/array.zig
+++ b/course/code/release/array.zig
@@ -121,6 +121,7 @@ const FuncInitArray = struct {
 const ComptimeInitArray = struct {
     // #region comptime_init_array
     const print = @import("std").debug.print;
+    const assert = @import("std").debug.assert;
 
     pub fn main() void {
         const fancy_array = comptime init: {
@@ -130,6 +131,7 @@ const ComptimeInitArray = struct {
             }
             break :init initial_value;
         };
+        comptime assert(fancy_array[9] == 9);
         print("{any}\n", .{fancy_array});
     }
     // #endregion comptime_init_array

--- a/course/code/release/array.zig
+++ b/course/code/release/array.zig
@@ -123,7 +123,7 @@ const ComptimeInitArray = struct {
     const print = @import("std").debug.print;
 
     pub fn main() void {
-        const fancy_array = init: {
+        const fancy_array = comptime init: {
             var initial_value: [10]usize = undefined;
             for (&initial_value, 0..) |*pt, i| {
                 pt.* = i;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated array initialization examples across course lessons and the release example.
  * Examples now explicitly evaluate array initialization at compile time and verify the final element.
  * Added an online Compiler Explorer example to the compile-time array initialization guide.
  * Improved consistency and accuracy when demonstrating compile-time array construction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->